### PR TITLE
Support custom cookie jars on the server side

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ persistStore(store, { storage: new CookieStorage({
 
 
 ### Server
-
 ```js
 import { persistStore, autoRehydrate } from 'redux-persist'
 import CookieStorage from 'redux-persist-cookie-storage'
@@ -52,13 +51,24 @@ const app = new Express()
 
 app.use(cookieParser())
 
+// cookies can be a plain object
 app.use((req, res) => {
   const store = createStore(reducer, undefined, autoRehydrate())
-  persistStore(store, { storage: new CookieStorage({ cookies: req.cookies }) })
+  const cookies = req.cookies
+  persistStore(store, { storage: new CookieStorage({ cookies }) })
+})
+
+// or an actual cookie jar
+import Cookies from 'cookies'
+app.use(Cookies.express())
+
+app.use((req, res) => {
+  const store = createStore(reducer, undefined, autoRehydrate())
+  const cookies = new Cookies(req, res)
+  persistStore(store, { storage: new CookieStorage({ cookies }) })
 })
 
 ```
-
 N.B.: Custom expiration times are not supported server-side at the moment.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ persistStore(store, { storage: new CookieStorage({
 })
 ```
 
-
-
 ### Server
 ```js
+// Read-only mode: Use plain object output of cookie parser
 import { persistStore, autoRehydrate } from 'redux-persist'
 import CookieStorage from 'redux-persist-cookie-storage'
 import cookieParser from 'cookie-parser'
@@ -51,15 +50,19 @@ const app = new Express()
 
 app.use(cookieParser())
 
-// cookies can be a plain object
 app.use((req, res) => {
   const store = createStore(reducer, undefined, autoRehydrate())
   const cookies = req.cookies
   persistStore(store, { storage: new CookieStorage({ cookies }) })
 })
 
-// or an actual cookie jar
+// Read-write mode: Use actual cookie jar implementation
+import { persistStore, autoRehydrate } from 'redux-persist'
+import CookieStorage from 'redux-persist-cookie-storage'
 import Cookies from 'cookies'
+
+const app = new Express()
+
 app.use(Cookies.express())
 
 app.use((req, res) => {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-spies": "^0.7.1",
     "jsdom": "^9.5.0",
     "mocha": "^3.0.2"
   },

--- a/src/redux-persist-cookie-storage.js
+++ b/src/redux-persist-cookie-storage.js
@@ -15,8 +15,12 @@ function CookieStorage(options) {
     this.cookies = Cookies(options.windowRef);
   } else if (typeof window !== 'undefined') {
     this.cookies = Cookies;
-  } else {
-    this.cookies = new FakeCookieJar(options.cookies);
+  } else if (options.cookies) {
+    if ('get' in options.cookies && 'set' in options.cookies && 'expire' in options.cookies) {
+      this.cookies = options.cookies
+    } else {
+      this.cookies = new FakeCookieJar(options.cookies);
+    }
   }
 }
 


### PR DESCRIPTION
this allows a caller to pass in an instantiated cookie jar as the `cookies` option.

fwiw this was the only way i could get server-side redux actions to set cookies on the initial network response (as soon as the client side rendered the cookies would get set there)