### PR TITLE
Add max-age support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,33 @@ const store = createStore(reducer, undefined, autoRehydrate())
 // By default, session cookies are used
 persistStore(store, { storage: new CookieStorage() })
 
-// Expiration time can be set via options
+// Expiration time and maxAge can be set via options
+
+const expires = new Date()
+expires.setFullYear(expires.getFullYear() + 1)
+
 persistStore(store, { storage: new CookieStorage({
     expiration: {
+      'default': expires, // Cookies expire one year from when the above code runs
+    },
+    maxAge: {
       'default': 365 * 86400 // Cookies expire after one year
-    }
+    },
   })
 })
 
-// Default expiration time can be overridden for specific parts of the store:
+// Default expiration and maxAge time can be overridden for specific parts of the store:
+const expires = new Date()
+expires.setFullYear(expires.getFullYear() + 1)
+
 persistStore(store, { storage: new CookieStorage({
     expiration: {
       'default': null, // Session cookies used by default
+      'storeKey': expires // State in key `storeKey` expires in one year from when the above code runs
+    },
+    maxAge: {
       'storeKey': 600 // State in key `storeKey` expires after 10 minutes
-    }
+    },
   })
 })
 ```

--- a/src/redux-persist-cookie-storage.js
+++ b/src/redux-persist-cookie-storage.js
@@ -3,12 +3,16 @@ var FakeCookieJar = require('./fake-cookie-jar');
 
 function CookieStorage(options) {
   options = options || {};
-
   this.keyPrefix = options.keyPrefix || '';
   this.indexKey = options.indexKey || 'reduxPersistIndex';
   this.expiration = options.expiration || {};
   if (!this.expiration.default) {
     this.expiration.default = null;
+  }
+
+  this.maxAge = options.maxAge || {};
+  if (!this.maxAge.default) {
+    this.maxAge.default = null;
   }
 
   if (options.windowRef) {
@@ -31,12 +35,22 @@ CookieStorage.prototype.getItem = function (key, callback) {
 CookieStorage.prototype.setItem = function (key, value, callback) {
   var options = {};
 
+  // handle expires
   var expires = this.expiration.default;
   if (typeof this.expiration[key] !== 'undefined') {
     expires = this.expiration[key]
   }
   if (expires) {
-    options["expires"] = expires;
+    options.expires = expires;
+  }
+
+  // handle maxAge
+  var maxAge = this.maxAge.default;
+  if (typeof this.maxAge[key] !== 'undefined') {
+    maxAge = this.maxAge[key]
+  }
+  if (maxAge) {
+    options.maxAge = maxAge;
   }
 
   this.cookies.set(this.keyPrefix + key, value, options);
@@ -45,7 +59,10 @@ CookieStorage.prototype.setItem = function (key, value, callback) {
 
   var indexOptions = {};
   if (this.expiration.default) {
-    indexOptions["expires"] = this.expiration.default;
+    indexOptions.expires = this.expiration.default;
+  }
+  if (this.maxAge.default) {
+    indexOptions.maxAge = this.maxAge.default;
   }
 
   this.getAllKeys(function (error, allKeys) {


### PR DESCRIPTION
it seems like the implementation of `expiration` is closer to `max-age`. i think some cookie implementations will interpret an integer `expires` value as "expire N seconds from now" but most i've seen want a `Date` object instead. 

this change adds support for `maxAge`. i also changed the docs a bit around the usage of `expiration` but i didn't change the tests there - it may be that i'm missing something and things work the way they should?