### PR TITLE
Support redux-persist version 5

### DIFF
--- a/src/redux-persist-cookie-storage.js
+++ b/src/redux-persist-cookie-storage.js
@@ -82,7 +82,7 @@ CookieStorage.prototype.getAllKeys = function (callback) {
   }
 
   if (callback) {
-      callback(result);
+      callback(null, result);
   }
   return Promise.resolve(result);
 }

--- a/src/redux-persist-cookie-storage.js
+++ b/src/redux-persist-cookie-storage.js
@@ -26,7 +26,9 @@ function CookieStorage(options) {
 
 CookieStorage.prototype.getItem = function (key, callback) {
   var item = this.cookies.get(this.keyPrefix + key) || 'null';
-  callback(null, item);
+  if (callback) {
+    callback(null, item);
+  }
   return Promise.resolve(item);
 }
 
@@ -54,7 +56,9 @@ CookieStorage.prototype.setItem = function (key, value, callback) {
       allKeys.push(key);
       this.cookies.set(this.indexKey, JSON.stringify(allKeys), indexOptions);
     }
-    callback(null);
+    if (callback) {
+      callback(null);
+    }
     return Promise.resolve(null);
   }.bind(this));
 }
@@ -68,7 +72,9 @@ CookieStorage.prototype.removeItem = function (key, callback) {
     });
 
     this.cookies.set(this.indexKey, JSON.stringify(allKeys));
-    callback(null);
+    if (callback) {
+      callback(null);
+    }
     return Promise.resolve(null);
   }.bind(this));
 }

--- a/test/redux-persist-cookie-storage-test.js
+++ b/test/redux-persist-cookie-storage-test.js
@@ -38,6 +38,21 @@ describe('CookieStorage', function () {
         }, { cookieJar: cookieJar });
       });
 
+      it('stores item as session cookies by default and returns a promise', function (done) {
+          var cookieJar = jsdom.createCookieJar();
+
+          withDOM(function (err, window) {
+              var storage = new CookieStorage({ windowRef: window, expiration: { default: null} });
+
+              storage.setItem('test', JSON.stringify({ foo: 'bar' }))
+                .then(function () {
+                  expect(JSON.parse(storage.cookies.get('test'))).to.eql({ foo: 'bar' });
+                  expect(cookieJar.store.idx.blank['/'].test.expires).to.eql('Infinity')
+                  done();
+                })
+          }, { cookieJar: cookieJar });
+      });
+
       it('stores an item as a cookie with expiration time', function (done) {
         var cookieJar = jsdom.createCookieJar();
 
@@ -179,6 +194,19 @@ describe('CookieStorage', function () {
         });
       });
 
+      it('gets an item stored as cookie and returns a promise', function (done) {
+        withDOM(function (err, window) {
+          var storage = new CookieStorage({ windowRef: window });
+          storage.cookies.set('test', JSON.stringify({ foo: 'bar' }));
+
+          storage.getItem('test')
+            .then(function (result) {
+              expect(JSON.parse(result)).to.eql({ foo: 'bar' });
+              done();
+            })
+        });
+      });
+
       it('returns null when the item isn\'t available', function (done) {
         withDOM(function (err, window) {
           var storage = new CookieStorage({ windowRef: window });
@@ -201,6 +229,19 @@ describe('CookieStorage', function () {
             expect(storage.cookies.get('reduxPersist_test')).not.to.be.defined;
             done();
           });
+        });
+      });
+
+      it('removes the item\'s cookie and returns a promise', function (done) {
+        withDOM(function (err, window) {
+          var storage = new CookieStorage({ windowRef: window });
+          storage.cookies.set('reduxPersist_test', JSON.stringify({ foo: 'bar' }));
+
+          storage.removeItem('test')
+            .then(function () {
+              expect(storage.cookies.get('reduxPersist_test')).not.to.be.defined;
+              done();
+            })
         });
       });
 
@@ -227,9 +268,21 @@ describe('CookieStorage', function () {
           var storage = new CookieStorage({ windowRef: window });
           storage.cookies.set('reduxPersistIndex', JSON.stringify(['foo', 'bar']));
 
+          storage.getAllKeys(function (error, result) {
+              expect(result).to.eql(['foo', 'bar']);
+              done();
+          });
+        });
+      });
+
+      it('returns a list of persisted keys and returns a promise', function (done) {
+        withDOM(function (err, window) {
+          var storage = new CookieStorage({ windowRef: window });
+          storage.cookies.set('reduxPersistIndex', JSON.stringify(['foo', 'bar']));
+
           storage.getAllKeys().then(function (result) {
-            expect(result).to.eql(['foo', 'bar']);
-            done();
+              expect(result).to.eql(['foo', 'bar']);
+              done();
           });
         });
       });

--- a/test/redux-persist-cookie-storage-test.js
+++ b/test/redux-persist-cookie-storage-test.js
@@ -54,7 +54,7 @@ describe('CookieStorage', function () {
             setTimeout(function() {
               expect(storage.cookies.get('test')).to.be.undefined;
               done();
-            }, 2e3);
+            }, 1e3);
           });
         }, { cookieJar: cookieJar });
       });
@@ -133,9 +133,9 @@ describe('CookieStorage', function () {
           var storage = new CookieStorage({ windowRef: window });
 
           storage.setItem('test', { foo: 'bar' }, function () {
-            storage.getAllKeys(function (error, result) {
-              expect(result).to.eql(['test'])
-              done();
+            storage.getAllKeys().then(function(result) {
+                expect(result).to.eql(['test'])
+                done()
             });
           });
         });
@@ -150,15 +150,15 @@ describe('CookieStorage', function () {
           });
 
           storage.setItem('test', { foo: 'bar' }, function () {
-            storage.getAllKeys(function (error, result) {
+            storage.getAllKeys().then(function (result) {
               expect(result).to.eql(['test'])
 
               setTimeout(function() {
-                storage.getAllKeys(function (error, result) {
+                storage.getAllKeys().then(function (result) {
                   expect(result).to.eql([])
                   done();
                 });
-              }, 2e3);
+              }, 1e3);
             });
           });
         });
@@ -211,7 +211,7 @@ describe('CookieStorage', function () {
 
           storage.setItem('test', { foo: 'bar' }, function () {
             storage.removeItem('test', function () {
-              storage.getAllKeys(function (error, result) {
+              storage.getAllKeys().then(function (result) {
                 expect(result).to.eql([]);
                 done();
               });
@@ -227,7 +227,7 @@ describe('CookieStorage', function () {
           var storage = new CookieStorage({ windowRef: window });
           storage.cookies.set('reduxPersistIndex', JSON.stringify(['foo', 'bar']));
 
-          storage.getAllKeys(function (error, result) {
+          storage.getAllKeys().then(function (result) {
             expect(result).to.eql(['foo', 'bar']);
             done();
           });
@@ -258,7 +258,7 @@ describe('CookieStorage', function () {
           var storage = new CookieStorage({ cookies });
 
           storage.setItem('test', { foo: 'bar' }, function () {
-            storage.getAllKeys(function (error, result) {
+            storage.getAllKeys().then(function (result) {
               expect(result).to.eql(['test'])
               if (isSpy(cookies)) {
                 expect(cookies.set).to.have.been.called;
@@ -322,7 +322,7 @@ describe('CookieStorage', function () {
 
           storage.setItem('test', { foo: 'bar' }, function () {
             storage.removeItem('test', function () {
-              storage.getAllKeys(function (error, result) {
+              storage.getAllKeys().then(function (result) {
                 expect(result).to.eql([]);
                 if (isSpy(cookies)) {
                   expect(cookies.set).to.have.been.called;
@@ -340,7 +340,7 @@ describe('CookieStorage', function () {
           var storage = new CookieStorage({ cookies });
           storage.cookies.set('reduxPersistIndex', JSON.stringify(['foo', 'bar']));
 
-          storage.getAllKeys(function (error, result) {
+          storage.getAllKeys().then(function (result) {
             expect(result).to.eql(['foo', 'bar']);
             if (isSpy(cookies)) {
               expect(cookies.set).to.have.been.called;


### PR DESCRIPTION
# Pull Request

### What is accomplished by the PR?
The cookie storage now supports redux-persist 5
* Every method supports callback as parameter but also returns a Promise that resolves accordingly (this is for backwards compatibility to redux-persist-v4)

### Is there something controversial in your PR?
This PR introduces Promises to the the cookie-storage so it is no longer strictly ES 5.1 standard.
This was necessary because redux-persist 5 requires the adapters to return promises.

### Checklist

- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by this pr
